### PR TITLE
[MS] Added parsing of cell data

### DIFF
--- a/htmlutil/htmlutil.go
+++ b/htmlutil/htmlutil.go
@@ -1,6 +1,9 @@
 package htmlutil
 
 import (
+	"bytes"
+	"strings"
+
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 )
@@ -109,4 +112,32 @@ func FindNodesWithAttributes(n *html.Node, a atom.Atom, attr map[string]string) 
 		result = append(result, FindNodesWithAttributes(c, a, attr)...)
 	}
 	return result
+}
+
+// FindAllNodes returns all child nodes of any of the given types, in the order in which they are found (a depth-first search)
+func FindAllNodes(n *html.Node, all ...atom.Atom) []*html.Node {
+	var result []*html.Node
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		for _, a := range all {
+			if c.DataAtom == a {
+				result = append(result, c)
+				break
+			}
+		}
+		result = append(result, FindAllNodes(c, all...)...)
+	}
+	return result
+}
+
+// GetText returns the text content of the given node, including the text content of all child nodes. Extraneous newline characters are removed.
+func GetText(n *html.Node) string {
+	var buffer bytes.Buffer
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.TextNode {
+			buffer.WriteString(c.Data)
+		} else {
+			buffer.WriteString(GetText(c))
+		}
+	}
+	return strings.Trim(buffer.String(), "\n")
 }

--- a/htmlutil/htmlutil_test.go
+++ b/htmlutil/htmlutil_test.go
@@ -221,7 +221,7 @@ func TestFindNodes(t *testing.T) {
 		node := CreateNode("div", atom.Div,
 			CreateNode("p", atom.P))
 
-		result := FindNode(node, atom.Span)
+		result := FindNodes(node, atom.Span)
 		So(result, ShouldBeNil)
 	})
 }
@@ -242,4 +242,40 @@ func TestFindNodesWithAttributes(t *testing.T) {
 		}
 	})
 
+}
+
+func TestFindAllNodes(t *testing.T) {
+	Convey("FindAllNodes should return the all nodes of all requested types", t, func() {
+
+		node := CreateNode("div", atom.Div,
+			CreateNode("p", atom.P),
+			CreateNode("div", atom.Div, CreateNode("p", atom.P)),
+			CreateNode("span", atom.Span))
+
+		result := FindAllNodes(node, atom.Span, atom.P)
+		So(len(result), ShouldEqual, 3)
+	})
+
+	Convey("FindAllNodes should return nil if there is no child node of the requested type", t, func() {
+
+		node := CreateNode("div", atom.Div,
+			CreateNode("p", atom.P))
+
+		result := FindAllNodes(node, atom.Span, atom.Div)
+		So(result, ShouldBeNil)
+	})
+}
+
+func TestGetText(t *testing.T) {
+	Convey("GetText should return the text content of the node", t, func() {
+
+		node := CreateNode("div", atom.Div,
+			"\n",
+			CreateNode("p", atom.P, "hello "),
+			CreateNode("div", atom.Div, CreateNode("p", atom.P, "world")),
+			CreateNode("span", atom.Span, "!"))
+
+		result := GetText(node)
+		So(result, ShouldEqual, "hello world!")
+	})
 }

--- a/models/models.go
+++ b/models/models.go
@@ -41,6 +41,7 @@ type ParseRequest struct {
 	Footnotes          []string `json:"footnotes"`
 	StyleClass         string   `json:"style_class"`
 	TableHTML          string   `json:"table_html"`
+	IncludeThead       bool     `json:"include_thead"` 		  // if true, any rows in thead will be parsed as if they are in tbody
 	HeaderRows         int      `json:"header_rows"`
 	HeaderCols         int      `json:"header_cols"`
 	CurrentTableWidth  int      `json:"current_table_width"`  // used to convert column width from pixels to %

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -1,0 +1,177 @@
+package parser_test
+
+import (
+	"testing"
+
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ONSdigital/dp-table-renderer/htmlutil"
+	"github.com/ONSdigital/dp-table-renderer/models"
+	"github.com/ONSdigital/dp-table-renderer/parser"
+	. "github.com/smartystreets/goconvey/convey"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+func TestParseHTML(t *testing.T) {
+	Convey("ParseHTML should create a valid RenderRequest", t, func() {
+
+		request := models.ParseRequest{
+			Filename:   "myFilename",
+			Title:      "myTitle",
+			Subtitle:   "mySubtitle",
+			Source:     "mySource",
+			URI:        "myURI",
+			StyleClass: "myStyleClass",
+			Footnotes:  []string{"Note0", "Note1"},
+			TableHTML:  "<table></table>"}
+
+		resultBytes, err := parser.ParseHTML(&request)
+
+		So(err, ShouldBeNil)
+		So(resultBytes, ShouldNotBeNil)
+
+		result := parser.ResponseModel{}
+		err = json.Unmarshal(resultBytes, &result)
+		So(err, ShouldBeNil)
+		So(result, ShouldNotBeNil)
+		So(result.JSON, ShouldNotBeNil)
+		So(result.JSON.Filename, ShouldEqual, request.Filename)
+		So(result.JSON.Title, ShouldEqual, request.Title)
+		So(result.JSON.Subtitle, ShouldEqual, request.Subtitle)
+		So(result.JSON.Source, ShouldEqual, request.Source)
+		So(result.JSON.URI, ShouldEqual, request.URI)
+		So(result.JSON.StyleClass, ShouldEqual, request.StyleClass)
+		So(result.JSON.TableType, ShouldEqual, "generated-table")
+		So(result.JSON.Footnotes, ShouldResemble, request.Footnotes)
+		So(result.PreviewHTML, ShouldNotBeNil)
+
+		nodes, err := html.ParseFragment(strings.NewReader(result.PreviewHTML), &html.Node{
+			Type:     html.ElementNode,
+			Data:     "body",
+			DataAtom: atom.Body,
+		})
+		So(err, ShouldBeNil)
+		// PreviewHTML should contain a div that contains a table
+		So(len(nodes), ShouldBeGreaterThanOrEqualTo, 1)
+		node := nodes[0]
+		So(node.DataAtom, ShouldEqual, atom.Div)
+		So(htmlutil.FindNode(node, atom.Table), ShouldNotBeNil)
+	})
+
+	Convey("ParseHTML should parse the cells correctly, ignoring thead", t, func() {
+		response := invokeParseHTML("<table>"+
+			"<thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>"+
+			"<tbody>"+
+			"<tr><td>r0c0</td><td>r0c1</td><td>r0c2</td></tr>"+
+			"<tr><td>r1c0</td><td>r1c1</td><td>r1c2</td></tr>"+
+			"<tr><td>r2c0</td><td>r2c1</td><td>r2c2</td></tr>"+
+			"</tbody>"+
+			"</table>", false, 0, 0)
+
+		data := response.JSON.Data
+		So(len(data), ShouldEqual, 3)
+		for r, row := range data {
+			So(len(row), ShouldEqual, 3)
+			for c, cell := range row {
+				So(cell, ShouldEqual, fmt.Sprintf("r%dc%d", r, c))
+			}
+		}
+	})
+
+	Convey("ParseHTML should parse the cells correctly, including thead", t, func() {
+		response := invokeParseHTML("<table>"+
+			"<thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>"+
+			"<tbody>"+
+			"<tr><td>r0c0</td><td>r0c1</td><td>r0c2</td></tr>"+
+			"<tr><td>r1c0</td><td>r1c1</td><td>r1c2</td></tr>"+
+			"<tr><td>r2c0</td><td>r2c1</td><td>r2c2</td></tr>"+
+			"</tbody>"+
+			"</table>", true, 0, 0)
+
+		data := response.JSON.Data
+		So(len(data), ShouldEqual, 4)
+	})
+
+	Convey("ParseHTML should parse the cells correctly where there is no tbody element", t, func() {
+		response := invokeParseHTML("<table>"+
+			"<tr><td>r0c0</td><td>r0c1</td><td>r0c2</td></tr>"+
+			"<tr><td>r1c0</td><td>r1c1</td><td>r1c2</td></tr>"+
+			"<tr><td>r2c0</td><td>r2c1</td><td>r2c2</td></tr>"+
+			"</table>", false, 0, 0)
+
+		data := response.JSON.Data
+		So(len(data), ShouldEqual, 3)
+		for r, row := range data {
+			So(len(row), ShouldEqual, 3)
+			for c, cell := range row {
+				So(cell, ShouldEqual, fmt.Sprintf("r%dc%d", r, c))
+			}
+		}
+	})
+
+	Convey("ParseHTML should parse td cells correctly", t, func() {
+		response := invokeParseHTML("<table>"+
+			"<tr><th>r0c0</th><td>r0c1</td><td>r0c2</td></tr>"+
+			"<tr><th>r1c0</th><td>r1c1</td><td>r1c2</td></tr>"+
+			"<tr><th>r2c0</th><td>r2c1</td><td>r2c2</td></tr>"+
+			"</table>", false, 0, 0)
+
+		data := response.JSON.Data
+		So(len(data), ShouldEqual, 3)
+		for r, row := range data {
+			So(len(row), ShouldEqual, 3)
+			for c, cell := range row {
+				So(cell, ShouldEqual, fmt.Sprintf("r%dc%d", r, c))
+			}
+		}
+	})
+
+	Convey("ParseHTML should return an error if the request contains invalid html", t, func() {
+		request := models.ParseRequest{Filename: "myFilename", TableHTML: "<table"}
+
+		result, err := parser.ParseHTML(&request)
+
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("ParseHTML should return an error if the request does not contain a table", t, func() {
+		request := models.ParseRequest{Filename: "myFilename", TableHTML: "<div></div>"}
+
+		result, err := parser.ParseHTML(&request)
+
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+}
+
+func invokeParseHTML(requestTable string, includeThead bool, headerRows int, headerCols int) *parser.ResponseModel {
+	request := models.ParseRequest{
+		Filename:     "myFilename",
+		Title:        "myTitle",
+		Subtitle:     "mySubtitle",
+		Source:       "mySource",
+		URI:          "myURI",
+		StyleClass:   "myStyleClass",
+		Footnotes:    []string{"Note0", "Note1"},
+		TableHTML:    requestTable,
+		IncludeThead: includeThead,
+		HeaderRows:   headerRows,
+		HeaderCols:   headerCols}
+
+	resultBytes, err := parser.ParseHTML(&request)
+
+	So(err, ShouldBeNil)
+	So(resultBytes, ShouldNotBeNil)
+
+	result := parser.ResponseModel{}
+	err = json.Unmarshal(resultBytes, &result)
+	So(err, ShouldBeNil)
+	So(result, ShouldNotBeNil)
+
+	return &result
+}


### PR DESCRIPTION
The /parse/html endpoint is now capable of parsing an html table (e.g. as generated by handsontable) and returning the json that should be sent to the /render/html endpoint. It doesn't yet specify formats but the basic content is there.