### PR TITLE
[MS] omitted empty fields in returned json, ensured units are copied from parse request to response

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -29,13 +29,13 @@ var (
 
 // RenderRequest represents a structure for a table render job
 type RenderRequest struct {
-	Title         string         `json:"title"`
-	Subtitle      string         `json:"subtitle"`
-	Source        string         `json:"source"`
-	TableType     string         `json:"type"`
-	TableVersion  string         `json:"type_version"`
-	Filename      string         `json:"filename"`
-	Units         string         `json:"units"`
+	Title         string         `json:"title,omitempty"`
+	Subtitle      string         `json:"subtitle,omitempty"`
+	Source        string         `json:"source,omitempty"`
+	TableType     string         `json:"type,omitempty"`
+	TableVersion  string         `json:"type_version,omitempty"`
+	Filename      string         `json:"filename,omitempty"`
+	Units         string         `json:"units,omitempty"`
 	RowFormats    []RowFormat    `json:"row_formats"`
 	ColumnFormats []ColumnFormat `json:"column_formats"`
 	CellFormats   []CellFormat   `json:"cell_formats"`
@@ -76,28 +76,28 @@ type ParseAlignments struct {
 
 // RowFormat allows us to specify that a row contains headings, and provide a style for html
 type RowFormat struct {
-	Row           int    `json:"row"`            // the index of the row the format applies to
-	VerticalAlign string `json:"vertical_align"` // must be Top, Middle or Bottom to be applied
-	Heading       bool   `json:"heading"`
-	Height        string `json:"height"`
+	Row           int    `json:"row"`                      // the index of the row the format applies to
+	VerticalAlign string `json:"vertical_align,omitempty"` // must be Top, Middle or Bottom to be applied
+	Heading       bool   `json:"heading,omitempty"`
+	Height        string `json:"height,omitempty"`
 }
 
 // ColumnFormat allows us to specify that a column contains headings, specify alignment and provide a style for html
 type ColumnFormat struct {
-	Column  int    `json:"col"`   // the index of the column the format applies to
-	Align   string `json:"align"` // must be Left, Center or Right to be applied
-	Heading bool   `json:"heading"`
-	Width   string `json:"width"`
+	Column  int    `json:"col"`             // the index of the column the format applies to
+	Align   string `json:"align,omitempty"` // must be Left, Center or Right to be applied
+	Heading bool   `json:"heading,omitempty"`
+	Width   string `json:"width,omitempty"`
 }
 
-// CellFormat allows us to specify alignment and style, that a cell contains a heading, and how to merge cells
+// CellFormat allows us to specify alignment and how to merge cells
 type CellFormat struct {
 	Row           int    `json:"row"`
 	Column        int    `json:"col"`
-	Align         string `json:"align"`
-	VerticalAlign string `json:"vertical_align"` // must be Top, Middle or Bottom to be applied
-	Rowspan       int    `json:"rowspan"`
-	Colspan       int    `json:"colspan"`
+	Align         string `json:"align,omitempty"`          // must be Left, Center or Right to be applied
+	VerticalAlign string `json:"vertical_align,omitempty"` // must be Top, Middle or Bottom to be applied
+	Rowspan       int    `json:"rowspan,omitempty"`
+	Colspan       int    `json:"colspan,omitempty"`
 }
 
 // CreateRenderRequest manages the creation of a RenderRequest from a reader

--- a/parser/html.go
+++ b/parser/html.go
@@ -59,6 +59,7 @@ func ParseHTML(request *models.ParseRequest) ([]byte, error) {
 		Title:        request.Title,
 		Subtitle:     request.Subtitle,
 		Source:       request.Source,
+		Units:        request.Units,
 		TableType:    tableType,
 		TableVersion: tableVersion,
 		Footnotes:    request.Footnotes}

--- a/parser/html.go
+++ b/parser/html.go
@@ -202,7 +202,11 @@ func createColumnFormats(model *parseModel) map[int]models.ColumnFormat {
 	}
 	// extract widths from col elements - assume that col elements do not have a colspan
 	// TODO handle cases where col elements have colspan
-	for i, col := range h.FindNodes(model.tableNode, atom.Col) {
+	colgroup := h.FindNodes(model.tableNode, atom.Col)
+	if len(colgroup) > 0 && model.request.IgnoreFirstColumn {
+		colgroup = colgroup[1:]
+	}
+	for i, col := range colgroup {
 		width := extractWidth(model, col)
 		if len(width) > 0 {
 			format := colFormats[i]

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -38,6 +38,7 @@ func TestParseHTML(t *testing.T) {
 		So(result.JSON.Title, ShouldEqual, request.Title)
 		So(result.JSON.Subtitle, ShouldEqual, request.Subtitle)
 		So(result.JSON.Source, ShouldEqual, request.Source)
+		So(result.JSON.Units, ShouldEqual, request.Units)
 		So(result.JSON.TableType, ShouldEqual, "table")
 		So(result.JSON.TableVersion, ShouldEqual, "2")
 		So(result.JSON.Footnotes, ShouldResemble, request.Footnotes)

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -295,6 +295,28 @@ func TestParseHTML_ColumnFormats(t *testing.T) {
 
 	})
 
+	Convey("First col of colgroup should be ignored if IgnoreFirstColumn is true", t, func() {
+		request := createParseRequest("<table>"+
+			"<colgroup><col style=\"width: 50px\" /><col style=\"width: 100px\" /><col/>"+
+			"<tbody>"+
+			"<tr><td>r0c0</td><td class=\"right\">r0c1</td><td>r0c2</td></tr>"+
+			"<tr><td>r1c0</td><td class=\"right\">r1c1</td><td>r1c2</td></tr>"+
+			"<tr><td>r2c0</td><td class=\"top right\">r2c1</td><td>r2c2</td></tr>"+
+			"</tbody>"+
+			"</table>", false, 0, 0)
+
+		request.SizeUnits = "%"
+		request.CurrentTableWidth = 200
+		request.IgnoreFirstColumn = true
+		response := invokeParseHTMLWithRequest(request)
+
+		formats := response.JSON.ColumnFormats
+		So(len(formats), ShouldEqual, 1)
+		So(formats[0].Align, ShouldEqual, models.AlignRight)
+		So(formats[0].Width, ShouldEqual, "50%")
+
+	})
+
 }
 
 func TestParseHTML_RowFormats(t *testing.T) {


### PR DESCRIPTION
omitted empty fields in returned json, ensured units are copied from parse request to response, and fixed a bug when parsing col elements.