### PR TITLE
[MS] Added justify alignment and an option to not specify column widths

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -19,12 +19,13 @@ var (
 
 // valid values for alignments in the various formats
 var (
-	AlignTop    = "Top"
-	AlignMiddle = "Middle"
-	AlignBottom = "Bottom"
-	AlignLeft   = "Left"
-	AlignCenter = "Center"
-	AlignRight  = "Right"
+	AlignTop     = "Top"
+	AlignMiddle  = "Middle"
+	AlignBottom  = "Bottom"
+	AlignLeft    = "Left"
+	AlignCenter  = "Center"
+	AlignRight   = "Right"
+	AlignJustify = "Justify"
 )
 
 // RenderRequest represents a structure for a table render job
@@ -66,12 +67,13 @@ type ParseRequest struct {
 
 // ParseAlignments defines the css classes that should be interpreted as defining the alignment of cells in a table
 type ParseAlignments struct {
-	Top    string `json:"top"`
-	Middle string `json:"middle"`
-	Bottom string `json:"bottom"`
-	Left   string `json:"left"`
-	Right  string `json:"right"`
-	Center string `json:"center"`
+	Top     string `json:"top"`
+	Middle  string `json:"middle"`
+	Bottom  string `json:"bottom"`
+	Left    string `json:"left"`
+	Right   string `json:"right"`
+	Center  string `json:"center"`
+	Justify string `json:"justify"`
 }
 
 // RowFormat allows us to specify that a row contains headings, and provide a style for html

--- a/models/models.go
+++ b/models/models.go
@@ -60,7 +60,7 @@ type ParseRequest struct {
 	CurrentTableWidth   int             `json:"current_table_width"`    // used to convert column width from pixels to %
 	CurrentTableHeight  int             `json:"current_table_height"`   // used to convert row height from pixels to %
 	SingleEmHeight      float32         `json:"single_em_height"`       // used to convert height/width from pixels to em. The height of the following: <div style="display: none; font-size: 1em; margin: 0; padding:0; height: auto; line-height: 1; border:0;">m</div>
-	SizeUnits           string          `json:"size_units"`             // 'em' or '%' - the desired unit for widths/heights
+	CellSizeUnits       string          `json:"cell_size_units"`        // 'em', '%' or 'auto' - the desired unit for widths/heights. Auto causes no widths/heights to be specified
 	ColumnWidthToIgnore string          `json:"column_width_to_ignore"` // if the source html applies a default column width that shouldn't be included in the output, specify it here. e.g. '50px'
 	AlignmentClasses    ParseAlignments `json:"alignment_classes"`      // The names of classes that should be interpreted as defining alignment of cells
 }
@@ -176,7 +176,7 @@ func (pr *ParseRequest) ValidateParseRequest() error {
 		missingFields = append(missingFields, "table_html")
 	}
 
-	switch units := pr.SizeUnits; units {
+	switch units := pr.CellSizeUnits; units {
 	case "%":
 		if pr.CurrentTableWidth <= 0 {
 			log.InfoC(pr.Filename, "size_units is '%' but current_table_width is not specified - cannot convert from px", nil)
@@ -185,8 +185,8 @@ func (pr *ParseRequest) ValidateParseRequest() error {
 		if pr.SingleEmHeight <= 0 {
 			log.InfoC(pr.Filename, "size_units is 'em' but single_em_height is not specified - cannot convert from px", nil)
 		}
-	case "":
-		// don't spam the logs
+	case "auto", "":
+		// nothing to do
 	default:
 		log.InfoC(pr.Filename, "Unknown size unit specified for width: "+units, nil)
 	}

--- a/parser/html.go
+++ b/parser/html.go
@@ -114,9 +114,10 @@ func createParseModel(request *models.ParseRequest, tableNode *html.Node) *parse
 	model.rowClasses, model.columnClasses = parseRowAndColumnClasses(model.cells)
 
 	model.alignMap = map[string]string{
-		request.AlignmentClasses.Left:   models.AlignLeft,
-		request.AlignmentClasses.Center: models.AlignCenter,
-		request.AlignmentClasses.Right:  models.AlignRight,
+		request.AlignmentClasses.Left:    models.AlignLeft,
+		request.AlignmentClasses.Center:  models.AlignCenter,
+		request.AlignmentClasses.Right:   models.AlignRight,
+		request.AlignmentClasses.Justify: models.AlignJustify,
 	}
 
 	model.valignMap = map[string]string{

--- a/parser/html.go
+++ b/parser/html.go
@@ -321,12 +321,15 @@ func createCellFormats(model *parseModel, rowFormats map[int]models.RowFormat, c
 
 // extractWidth extracts width from the style property of the node
 func extractWidth(model *parseModel, node *html.Node) string {
+	if model.request.CellSizeUnits == "auto" {
+		return ""
+	}
 	width := widthStylePattern.FindString(h.GetAttribute(node, "style"))
 	width = strings.Trim(strings.Replace(width, "width:", "", -1), " ")
 	width = strings.Replace(width, model.request.ColumnWidthToIgnore, "", -1)
 	// replace pixel width with % or em
 	if strings.HasSuffix(width, "px") {
-		switch units := model.request.SizeUnits; units {
+		switch units := model.request.CellSizeUnits; units {
 		case "%":
 			if model.request.CurrentTableWidth > 0 {
 				intWidth, err := strconv.Atoi(strings.Trim(width, "px"))

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -350,7 +350,7 @@ func TestParseHTML_CellFormats(t *testing.T) {
 			"<tr><td class=\"top right\">r0c0</td><td class=\"top\">r0c1</td><td class=\"top\">r0c2</td></tr>"+
 			"<tr><td class=\"right\">r1c0</td><td colspan=\"2\" rowspan=\"2\">r1c1</td><td>r1c2</td></tr>"+
 			"<tr><td class=\"right\">r2c0</td><td>r2c1</td><td>r2c2</td></tr>"+
-			"<tr><td class=\"top right\">r3c0</td><td colspan=\"2\">r3c1</td><td>r3c2</td></tr>"+
+			"<tr><td class=\"top right\">r3c0</td><td colspan=\"2\" class=\"justify\">r3c1</td><td>r3c2</td></tr>"+
 			"</tbody>"+
 			"</table>", false, 2, 0)
 
@@ -377,6 +377,7 @@ func TestParseHTML_CellFormats(t *testing.T) {
 		So(format, ShouldNotBeNil)
 		So(format.Colspan, ShouldEqual, 2)
 		So(format.Rowspan, ShouldEqual, 0)
+		So(format.Align, ShouldEqual, models.AlignJustify)
 	})
 
 	Convey("ParseHTML should not create formats when no formatting is present in the source table", t, func() {
@@ -425,12 +426,13 @@ func createParseRequest(requestTable string, hasHeaders bool, headerRows int, he
 		HeaderRows:        headerRows,
 		HeaderCols:        headerCols,
 		AlignmentClasses: models.ParseAlignments{
-			Top:    "top",
-			Middle: "middle",
-			Bottom: "bottom",
-			Left:   "left",
-			Center: "center",
-			Right:  "right",
+			Top:     "top",
+			Middle:  "middle",
+			Bottom:  "bottom",
+			Left:    "left",
+			Center:  "center",
+			Right:   "right",
+			Justify: "justify",
 		}}
 	return &request
 }

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -230,7 +230,7 @@ func TestParseHTML_ColumnFormats(t *testing.T) {
 			"</tbody>"+
 			"</table>", false, 0, 2)
 
-		request.SizeUnits = "em"
+		request.CellSizeUnits = "em"
 		request.SingleEmHeight = 15
 		response := invokeParseHTMLWithRequest(request)
 
@@ -246,6 +246,27 @@ func TestParseHTML_ColumnFormats(t *testing.T) {
 
 	})
 
+	Convey("Column width should be ignored", t, func() {
+		request := createParseRequest("<table>"+
+			"<colgroup><col style=\"foo: bar; width: 60px\" /><col style=\"width: 65px;\"/><col/>"+
+			"<tbody>"+
+			"<tr><td class=\"right\">r0c0</td><td>r0c1</td><td>r0c2</td></tr>"+
+			"<tr><td class=\"right\">r1c0</td><td>r1c1</td><td>r1c2</td></tr>"+
+			"<tr><td class=\"top right\">r2c0</td><td>r2c1</td><td>r2c2</td></tr>"+
+			"</tbody>"+
+			"</table>", false, 0, 2)
+
+		request.CellSizeUnits = "auto"
+		response := invokeParseHTMLWithRequest(request)
+
+		formats := response.JSON.ColumnFormats
+		So(len(formats), ShouldEqual, 2)
+		for _, format := range formats {
+			So(format.Width, ShouldBeEmpty)
+		}
+
+	})
+
 	Convey("Column width in pixels should be converted to percent", t, func() {
 		request := createParseRequest("<table>"+
 			"<colgroup><col style=\"foo: bar; width: 50px\" /><col/><col/>"+
@@ -256,7 +277,7 @@ func TestParseHTML_ColumnFormats(t *testing.T) {
 			"</tbody>"+
 			"</table>", false, 0, 2)
 
-		request.SizeUnits = "%"
+		request.CellSizeUnits = "%"
 		request.CurrentTableWidth = 200
 		response := invokeParseHTMLWithRequest(request)
 
@@ -305,7 +326,7 @@ func TestParseHTML_ColumnFormats(t *testing.T) {
 			"</tbody>"+
 			"</table>", false, 0, 0)
 
-		request.SizeUnits = "%"
+		request.CellSizeUnits = "%"
 		request.CurrentTableWidth = 200
 		request.IgnoreFirstColumn = true
 		response := invokeParseHTMLWithRequest(request)

--- a/renderer/html.go
+++ b/renderer/html.go
@@ -28,12 +28,13 @@ var (
 
 	// a map of the alignments to their css classes
 	cssAlignmentMap = map[string]string{
-		models.AlignTop:    "align-top",
-		models.AlignMiddle: "align-middle",
-		models.AlignBottom: "align-bottom",
-		models.AlignLeft:   "align-left",
-		models.AlignCenter: "align-center",
-		models.AlignRight:  "align-right",
+		models.AlignTop:     "align-top",
+		models.AlignMiddle:  "align-middle",
+		models.AlignBottom:  "align-bottom",
+		models.AlignLeft:    "align-left",
+		models.AlignCenter:  "align-center",
+		models.AlignRight:   "align-right",
+		models.AlignJustify: "align-justify",
 	}
 )
 

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -391,7 +391,7 @@ func TestRenderHTML_ColumnAndRowAlignment(t *testing.T) {
 		rowFormats := []models.RowFormat{{Row: 0, VerticalAlign: models.AlignTop}}
 		colFormats := []models.ColumnFormat{{Column: 0, Align: models.AlignRight}}
 		cellFormats := []models.CellFormat{{Row: 0, Column: 0, VerticalAlign: models.AlignBottom},
-			{Row: 1, Column: 0, Align: models.AlignLeft}}
+			{Row: 1, Column: 0, Align: models.AlignJustify}}
 		cells := [][]string{{"Cell 1", "Cell 2", "Cell 3", "Cell 4"}, {"Cell 1", "Cell 2", "Cell 3", "Cell 4"}}
 		request := models.RenderRequest{Filename: "myId", ColumnFormats: colFormats, RowFormats: rowFormats, CellFormats: cellFormats, Data: cells}
 		container, _ := invokeRenderHTML(&request)
@@ -416,7 +416,7 @@ func TestRenderHTML_ColumnAndRowAlignment(t *testing.T) {
 		So(len(td), ShouldEqual, len(request.Data[1]))
 		So(GetAttribute(td[0], "class"), ShouldNotContainSubstring, "bottom")
 		So(GetAttribute(td[0], "class"), ShouldNotContainSubstring, "right")
-		So(GetAttribute(td[0], "class"), ShouldContainSubstring, "left")
+		So(GetAttribute(td[0], "class"), ShouldContainSubstring, "justify")
 		So(GetAttribute(td[1], "class"), ShouldBeEmpty)
 	})
 }

--- a/renderer/xlsx.go
+++ b/renderer/xlsx.go
@@ -29,14 +29,15 @@ var (
 	formatFloat3dp = "0.000"
 	titleFormat    = &xlsxCellStyle{Font: xlsxFont{Bold: true}}
 
-	// a map of the alignments to their cxlsx equivalents
+	// a map of the alignments to their xlsx equivalents
 	xlsxAlignmentMap = map[string]string{
-		models.AlignTop:    "top",
-		models.AlignMiddle: "center",
-		models.AlignBottom: "", // bottom is the default, and doesn't seem to have a value in excelize
-		models.AlignLeft:   "left",
-		models.AlignCenter: "center",
-		models.AlignRight:  "right",
+		models.AlignTop:     "top",
+		models.AlignMiddle:  "center",
+		models.AlignBottom:  "", // bottom is the default, and doesn't seem to have a value in excelize
+		models.AlignLeft:    "left",
+		models.AlignCenter:  "center",
+		models.AlignRight:   "right",
+		models.AlignJustify: "justify",
 	}
 )
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -143,7 +143,7 @@ definitions:
           The alignment of the column.
           For html output this will be rendered as the name of a css class
           that is assumed to be defined in the containing page.
-        enum: [Left, Center, Right]
+        enum: [Left, Center, Right, Justify]
   CellFormat:
     description: |
       A specification that a given cell should be formatted in a particular way
@@ -162,7 +162,7 @@ definitions:
           The alignment of the column.
           For html output this will be rendered as the name of a css class
           that is assumed to be defined in the containing page.
-        enum: [Left, Center, Right]
+        enum: [Left, Center, Right, Justify]
       vertical_align:
         type: string
         description: |

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -199,12 +199,12 @@ definitions:
           type: integer
           description: |
             The number of column that should be rendered as headings, after ignoring the first row (if applicable).
-        size_units:
+        cell_size_units:
           type: string
           description: |
             The desired unit for cell widths/heights. Pixel widths will be converted to this unit, provided the
             required information is provided - see current_table_width and single_em_height.
-          enum: ["%", "em"]
+          enum: ["%", "em", "auto"]
         current_table_width:
           type: integer
           description: |


### PR DESCRIPTION
Added 'justify' as an alignment when rendering html and xlsx,
and the ability to not define column widths when parsing html to json