### PR TITLE
[MS] Removed the requirement to provide a filename, and removed empty footnotes on parsing

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -132,10 +132,6 @@ func (rr *RenderRequest) ValidateRenderRequest() error {
 
 	var missingFields []string
 
-	if len(rr.Filename) == 0 {
-		missingFields = append(missingFields, "filename")
-	}
-
 	if missingFields != nil {
 		return fmt.Errorf("Missing mandatory fields: %v", missingFields)
 	}
@@ -171,9 +167,6 @@ func (pr *ParseRequest) ValidateParseRequest() error {
 
 	var missingFields []string
 
-	if len(pr.Filename) == 0 {
-		missingFields = append(missingFields, "filename")
-	}
 	if len(pr.TableHTML) == 0 {
 		missingFields = append(missingFields, "table_html")
 	}

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -68,14 +68,6 @@ func TestCreateRenderRequestWithInvalidJSON(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err, ShouldResemble, ErrorParsingBody)
 	})
-	Convey("When a render request contains json with missing required fields, validation fails", t, func() {
-		request, err := CreateRenderRequest(strings.NewReader(`{"title":"foo"}`))
-
-		So(err, ShouldBeNil)
-		err = request.ValidateRenderRequest()
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, "filename")
-	})
 }
 
 func TestCreateParseRequestWithValidJSON(t *testing.T) {
@@ -131,6 +123,6 @@ func TestCreateParseRequestWithInvalidJSON(t *testing.T) {
 		So(err, ShouldBeNil)
 		err = request.ValidateParseRequest()
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, "filename")
+		So(err.Error(), ShouldContainSubstring, "table_html")
 	})
 }

--- a/parser/html.go
+++ b/parser/html.go
@@ -63,7 +63,7 @@ func ParseHTML(request *models.ParseRequest) ([]byte, error) {
 		KeepHeadersTogether: request.KeepHeadersTogether,
 		TableType:           tableType,
 		TableVersion:        tableVersion,
-		Footnotes:           request.Footnotes}
+	}
 
 	rowFormats := createRowFormats(model)
 	requestJSON.RowFormats = convertRowFormatsToSlice(rowFormats)
@@ -74,6 +74,8 @@ func ParseHTML(request *models.ParseRequest) ([]byte, error) {
 	requestJSON.CellFormats = createCellFormats(model, rowFormats, colFormats)
 
 	requestJSON.Data = parseData(model.cells)
+
+	requestJSON.Footnotes = parseFootnotes(request.Footnotes)
 
 	previewHTML, err := renderer.RenderHTML(requestJSON)
 	if err != nil {
@@ -106,9 +108,10 @@ func parseTableToNode(tableHTML string) (*html.Node, error) {
 
 // createParseModel creates a model from the input request, extracting all properties need to define the output from the input html
 func createParseModel(request *models.ParseRequest, tableNode *html.Node) *parseModel {
-	model := parseModel{}
-	model.request = request
-	model.tableNode = tableNode
+	model := parseModel{
+		request:   request,
+		tableNode: tableNode,
+	}
 
 	model.cells = getCells(tableNode, request.IgnoreFirstRow, request.IgnoreFirstColumn)
 
@@ -186,6 +189,17 @@ func parseRowAndColumnClasses(cells [][]*html.Node) ([]map[string]int, []map[str
 		}
 	}
 	return rowClasses, columnClasses
+}
+
+// parseFootnotes copies the given array, removing any empty strings
+func parseFootnotes(notes []string) []string {
+	footnotes := []string{}
+	for _, note := range notes {
+		if len(note) > 0 {
+			footnotes = append(footnotes, note)
+		}
+	}
+	return footnotes
 }
 
 // createColumnFormats uses the colgroup element to determine widths, and columnClasses to determine alignment

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -436,6 +436,25 @@ func TestParseHTML_KeepHeadingsTogether(t *testing.T) {
 
 }
 
+func TestParseHTML_Footnotes(t *testing.T) {
+
+	Convey("ParseHTML should remove empty footnotes", t, func() {
+		request := models.ParseRequest{
+			Footnotes:           []string{"first note", "", "second note", ""},
+			KeepHeadersTogether: true,
+			TableHTML:           `<table class="htCore"><tbody><tr><td class="">2016</td></tr></tbody></table>`,
+		}
+
+		response := invokeParseHTMLWithRequest(&request)
+
+		So(len(response.JSON.Footnotes), ShouldEqual, 2)
+		So(response.JSON.Footnotes[0], ShouldEqual, "first note")
+		So(response.JSON.Footnotes[1], ShouldEqual, "second note")
+
+	})
+
+}
+
 func getCellFormat(formats []models.CellFormat, row int, col int) *models.CellFormat {
 	for _, format := range formats {
 		if format.Row == row && format.Column == col {


### PR DESCRIPTION
Removed the requirement to provide a filename, as this is not available when a new table is created. 
Also stripped out empty strings from footnotes, as one is usually sent when generating a table in Florence.