### PR TITLE
[MS] Made 'auto' the default for parsing cell widths

### DIFF
--- a/parser/html.go
+++ b/parser/html.go
@@ -336,7 +336,7 @@ func createCellFormats(model *parseModel, rowFormats map[int]models.RowFormat, c
 
 // extractWidth extracts width from the style property of the node
 func extractWidth(model *parseModel, node *html.Node) string {
-	if model.request.CellSizeUnits == "auto" {
+	if len(model.request.CellSizeUnits) == 0 || model.request.CellSizeUnits == "auto" {
 		return ""
 	}
 	width := widthStylePattern.FindString(h.GetAttribute(node, "style"))

--- a/parser/html_test.go
+++ b/parser/html_test.go
@@ -267,6 +267,27 @@ func TestParseHTML_ColumnFormats(t *testing.T) {
 
 	})
 
+	Convey("Column width should be ignored", t, func() {
+		request := createParseRequest("<table>"+
+			"<colgroup><col style=\"foo: bar; width: 60px\" /><col style=\"width: 65px;\"/><col/>"+
+			"<tbody>"+
+			"<tr><td class=\"right\">r0c0</td><td>r0c1</td><td>r0c2</td></tr>"+
+			"<tr><td class=\"right\">r1c0</td><td>r1c1</td><td>r1c2</td></tr>"+
+			"<tr><td class=\"top right\">r2c0</td><td>r2c1</td><td>r2c2</td></tr>"+
+			"</tbody>"+
+			"</table>", false, 0, 2)
+
+		request.CellSizeUnits = ""
+		response := invokeParseHTMLWithRequest(request)
+
+		formats := response.JSON.ColumnFormats
+		So(len(formats), ShouldEqual, 2)
+		for _, format := range formats {
+			So(format.Width, ShouldBeEmpty)
+		}
+
+	})
+
 	Convey("Column width in pixels should be converted to percent", t, func() {
 		request := createParseRequest("<table>"+
 			"<colgroup><col style=\"foo: bar; width: 50px\" /><col/><col/>"+
@@ -483,6 +504,7 @@ func createParseRequest(requestTable string, hasHeaders bool, headerRows int, he
 		IgnoreFirstColumn:   hasHeaders,
 		HeaderRows:          headerRows,
 		HeaderCols:          headerCols,
+		CellSizeUnits:       "em",
 		AlignmentClasses: models.ParseAlignments{
 			Top:     "top",
 			Middle:  "middle",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -203,7 +203,8 @@ definitions:
           type: string
           description: |
             The desired unit for cell widths/heights. Pixel widths will be converted to this unit, provided the
-            required information is provided - see current_table_width and single_em_height.
+            required information is provided - see current_table_width and single_em_height. The default is 'auto',
+            in which case no table cell widths/heights will be specified.
           enum: ["%", "em", "auto"]
         current_table_width:
           type: integer


### PR DESCRIPTION
### What

Made 'auto' the default for parsing cell widths in the /parse/html endpoint