### PR TITLE
Fix - Add accessible text to back to table link

### DIFF
--- a/renderer/html.go
+++ b/renderer/html.go
@@ -242,6 +242,12 @@ func addFooterItemsToList(request *models.RenderRequest, ol *html.Node) {
 			h.Attr("class", "figure__footnote-back-link"),
 			h.Attr("href", "#"+tableID(request)),
 			backLinkText)
+
+		accessibleText := h.CreateNode("span", atom.Span,
+			h.Attr("class", "visuallyhidden"),
+			fmt.Sprintf(" %s", request.Title))
+		backLink.AppendChild(accessibleText)
+
 		li := h.CreateNode("li", atom.Li,
 			h.Attr("id", fmt.Sprintf("table-%s-note-%d", request.Filename, i+1)),
 			h.Attr("class", "figure__footnote-item"),

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -189,7 +189,7 @@ func TestRenderHTML_Footer(t *testing.T) {
 	})
 
 	Convey("Footnotes should end with a link back to the top of the table", t, func() {
-		request := models.RenderRequest{Filename: "myId", Footnotes: []string{"Note1", "Note2"}}
+		request := models.RenderRequest{Filename: "myId", Footnotes: []string{"Note1", "Note2"}, Title: "Table Title"}
 		container, _ := invokeRenderHTML(&request)
 		footer := FindNode(container, atom.Footer)
 		So(footer, ShouldNotBeNil)
@@ -201,7 +201,7 @@ func TestRenderHTML_Footer(t *testing.T) {
 			So(back.DataAtom, ShouldEqual, atom.A)
 			So(GetAttribute(back, "class"), ShouldEqual, "figure__footnote-back-link")
 			So(GetAttribute(back, "href"), ShouldEqual, "#table-"+request.Filename)
-			So(GetText(back), ShouldResemble, "Back to table")
+			So(GetText(back), ShouldResemble, "Back to table Table Title")
 		}
 	})
 


### PR DESCRIPTION
### What
Add text to describe which table the link takes the user back to you

### How to review
1. Load a page with a `v2` table with footnotes
1. See that the `Back to table` link is confusing in web and pdf
1. Load this branch
1. See that the title of the table is read as well by the screen reader
1. See that this title is included in the pdf

### Who can review
Anyone but me