### PR TITLE
Release - 1.1.0

### DIFF
--- a/renderer/html.go
+++ b/renderer/html.go
@@ -25,7 +25,6 @@ var (
 	unitsText          = "Units: "
 	notesText          = "Notes"
 	footnoteHiddenText = "Footnote "
-	backLinkText       = "Back to table"
 
 	// a map of the alignments to their css classes
 	cssAlignmentMap = map[string]string{
@@ -238,22 +237,10 @@ func addFooter(request *models.RenderRequest, parent *html.Node) {
 // addFooterItemsToList adds one li node for each footnote to the given list node
 func addFooterItemsToList(request *models.RenderRequest, ol *html.Node) {
 	for i, note := range request.Footnotes {
-		backLink := h.CreateNode("a", atom.A,
-			h.Attr("class", "figure__footnote-back-link"),
-			h.Attr("href", "#"+tableID(request)),
-			backLinkText)
-
-		accessibleText := h.CreateNode("span", atom.Span,
-			h.Attr("class", "visuallyhidden"),
-			fmt.Sprintf(" %s", request.Title))
-		backLink.AppendChild(accessibleText)
-
 		li := h.CreateNode("li", atom.Li,
 			h.Attr("id", fmt.Sprintf("table-%s-note-%d", request.Filename, i+1)),
 			h.Attr("class", "figure__footnote-item"),
-			parseValue(request, note),
-			" ",
-			backLink)
+			parseValue(request, note))
 		ol.AppendChild(li)
 		ol.AppendChild(h.Text("\n"))
 	}

--- a/renderer/html.go
+++ b/renderer/html.go
@@ -242,6 +242,12 @@ func addFooterItemsToList(request *models.RenderRequest, ol *html.Node) {
 			h.Attr("class", "figure__footnote-back-link"),
 			h.Attr("href", "#"+tableID(request)),
 			backLinkText)
+
+		accessibleText := h.CreateNode("span", atom.Span,
+			h.Attr("class", "visuallyhidden"),
+			fmt.Sprintf(" %s", request.Title))
+		backLink.AppendChild(accessibleText)
+
 		li := h.CreateNode("li", atom.Li,
 			h.Attr("id", fmt.Sprintf("table-%s-note-%d", request.Filename, i+1)),
 			h.Attr("class", "figure__footnote-item"),

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -188,16 +188,6 @@ func TestRenderHTML_Footer(t *testing.T) {
 		}
 	})
 
-	Convey("Footnotes should end with a link back to the top of the table", t, func() {
-		request := models.RenderRequest{Filename: "myId", Footnotes: []string{"Note1", "Note2"}, Title: "Table Title"}
-		container, _ := invokeRenderHTML(&request)
-		footer := FindNode(container, atom.Footer)
-		So(footer, ShouldNotBeNil)
-
-		notes := FindNodes(footer, atom.Li)
-		So(len(notes), ShouldEqual, len(request.Footnotes))
-	})
-
 	Convey("Footnotes should be properly parsed", t, func() {
 		request := models.RenderRequest{Filename: "myId", Footnotes: []string{"Note1", "Note2\nOn Two Lines"}}
 		_, result := invokeRenderHTML(&request)

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -189,7 +189,7 @@ func TestRenderHTML_Footer(t *testing.T) {
 	})
 
 	Convey("Footnotes should end with a link back to the top of the table", t, func() {
-		request := models.RenderRequest{Filename: "myId", Footnotes: []string{"Note1", "Note2"}}
+		request := models.RenderRequest{Filename: "myId", Footnotes: []string{"Note1", "Note2"}, Title: "Table Title"}
 		container, _ := invokeRenderHTML(&request)
 		footer := FindNode(container, atom.Footer)
 		So(footer, ShouldNotBeNil)
@@ -201,7 +201,7 @@ func TestRenderHTML_Footer(t *testing.T) {
 			So(back.DataAtom, ShouldEqual, atom.A)
 			So(GetAttribute(back, "class"), ShouldEqual, "figure__footnote-back-link")
 			So(GetAttribute(back, "href"), ShouldEqual, "#table-"+request.Filename)
-			So(GetText(back), ShouldResemble, "Back to table")
+			So(GetText(back), ShouldResemble, "Back to table Table Title")
 		}
 	})
 

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -196,13 +196,6 @@ func TestRenderHTML_Footer(t *testing.T) {
 
 		notes := FindNodes(footer, atom.Li)
 		So(len(notes), ShouldEqual, len(request.Footnotes))
-		for i := range request.Footnotes {
-			back := notes[i].LastChild
-			So(back.DataAtom, ShouldEqual, atom.A)
-			So(GetAttribute(back, "class"), ShouldEqual, "figure__footnote-back-link")
-			So(GetAttribute(back, "href"), ShouldEqual, "#table-"+request.Filename)
-			So(GetText(back), ShouldResemble, "Back to table Table Title")
-		}
 	})
 
 	Convey("Footnotes should be properly parsed", t, func() {


### PR DESCRIPTION
### What
Release 1.1.0
- Remove footnotes links that take you back to the table

### How to review
1. Load a table
1. See that there are footnotes links `Back to table`
1. Load this branch
1. See they are gone

### Who can review
Anyone but me
