### PR TITLE
Do not set empty cells as headers

### DIFF
--- a/renderer/html.go
+++ b/renderer/html.go
@@ -161,13 +161,14 @@ func addTableCell(model *tableModel, tr *html.Node, colText string, rowIdx int, 
 		return
 	}
 	value := parseValue(model.request, colText)
+	hasContent := len(colText) > 0
 	var node *html.Node
-	if model.rows[rowIdx].Heading {
+	if model.rows[rowIdx].Heading && hasContent {
 		node = h.CreateNode("th", atom.Th, h.Attr("scope", "col"), value)
 		if cell.colspan > 1 {
 			h.ReplaceAttribute(node, "scope", "colgroup")
 		}
-	} else if model.columns[colIdx].Heading {
+	} else if model.columns[colIdx].Heading && hasContent {
 		node = h.CreateNode("th", atom.Th, h.Attr("scope", "row"), value)
 		if cell.rowspan > 1 {
 			h.ReplaceAttribute(node, "scope", "rowgroup")

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -353,6 +353,21 @@ func TestRenderHTML_ColumnFormats(t *testing.T) {
 			So(GetAttribute(col, "style"), ShouldBeEmpty)
 		}
 	})
+
+	Convey("Column that have no content shold not become headers but instead td", t, func() {
+		colFormats := []models.ColumnFormat{{Column: 0, Heading: true}}
+		rowFormats := []models.RowFormat{{Row: 0, Heading: true}}
+		cells := [][]string{{"", "Head 1", "Head 2", "Head 3"}, {"Head 4", "Cell 2", "Cell 3", "Cell 4"}}
+		request := models.RenderRequest{Filename: "myId", ColumnFormats: colFormats, RowFormats: rowFormats, Data: cells}
+		container, _ := invokeRenderHTML(&request)
+		table := FindNode(container, atom.Table)
+
+		rows := FindNodes(table, atom.Tr)
+		headers := FindNodes(rows[0], atom.Th)
+		emptyHeaders := FindNodes(rows[0], atom.Td)
+		So(len(headers), ShouldEqual, len(cells[0])-1)
+		So(len(emptyHeaders), ShouldEqual, 1)
+	})
 }
 
 func TestRenderHTML_Rows(t *testing.T) {


### PR DESCRIPTION
### What

Do not set headers as `th` if they have no content e.g. top left where you have both row and column headers.

### How to review

1. Load a table where there is an empty cell in a header row/column
1. See that the empty cell is a `th`
1. Load this branch
1. See that the empty cell is a `td`

### Who can review
Anyone but me
